### PR TITLE
fix(launch_template): LaunchTemplateNetworkInterfaces.associatePublicIpAddress data …

### DIFF
--- a/src/launch-template/index.ts
+++ b/src/launch-template/index.ts
@@ -3374,7 +3374,7 @@ export interface LaunchTemplateNetworkInterfaces {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/launch_template#associate_public_ip_address LaunchTemplate#associate_public_ip_address}
   */
-  readonly associatePublicIpAddress?: string;
+  readonly associatePublicIpAddress?: boolean;
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/launch_template#delete_on_termination LaunchTemplate#delete_on_termination}
   */


### PR DESCRIPTION
Fixes [cdktf-provider-aws](https://github.com/cdktf/cdktf-provider-aws) `launch_template.LaunchTemplateNetworkInterfaces` attribute: `associate_public_ip_address`

The [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#associate_public_ip_address) specifies it is a boolean value but cdk assigns a `string` data type.